### PR TITLE
Remove a duplicated INTERNET permission in AndroidManifest.xml

### DIFF
--- a/DataCollectorsClients/VpnCollector/app/src/main/AndroidManifest.xml
+++ b/DataCollectorsClients/VpnCollector/app/src/main/AndroidManifest.xml
@@ -8,7 +8,6 @@
         android:minSdkVersion="19"
         android:targetSdkVersion="21" />
 
-    <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />


### PR DESCRIPTION
Remove a duplicated INTERNET permission as the build have gotten the below warning

DataCollectorsClients/VpnCollector/app/src/main/AndroidManifest.xml:23:5-67 Warning:
        Element uses-permission#android.permission.INTERNET at AndroidManifest.xml:23:5-67 duplicated with element declared at AndroidManifest.xml:11:5-67